### PR TITLE
Support custom anchor points for dimension labels

### DIFF
--- a/backend/functions/src/common/schemas/studio.ts
+++ b/backend/functions/src/common/schemas/studio.ts
@@ -23,6 +23,9 @@ export const DimensionLabelSchema = z.object({
   edge: z.string(),
   text: ExpressionSchema,
   offset: z.number().default(15),
+  startPos: z.tuple([ExpressionSchema, ExpressionSchema, ExpressionSchema]).optional(),
+  endPos: z.tuple([ExpressionSchema, ExpressionSchema, ExpressionSchema]).optional(),
+  offsetDirection: z.tuple([ExpressionSchema, ExpressionSchema, ExpressionSchema]).optional(),
 });
 export type DimensionLabel = z.infer<typeof DimensionLabelSchema>;
 
@@ -45,7 +48,7 @@ export type SlabComponent = z.infer<typeof baseComponentSchema> & {
 
 export const SlabComponentSchema: z.ZodType<SlabComponent> = baseComponentSchema.extend({
   children: z.lazy(() => z.array(SlabComponentSchema)).optional(),
-});
+}) as any;
 
 export const AssemblyVariableSchema = z.object({
   id: z.string(),

--- a/backend/functions/src/common/schemas/studio.ts
+++ b/backend/functions/src/common/schemas/studio.ts
@@ -46,6 +46,9 @@ export type SlabComponent = z.infer<typeof baseComponentSchema> & {
   children?: SlabComponent[] | undefined;
 };
 
+// `as any` is used below as a standard workaround in Zod when dealing with deeply nested
+// or mutually recursive schemas to prevent TypeScript compiler instantiation depth errors,
+// while keeping the external type signature (`z.ZodType<SlabComponent>`) intact.
 export const SlabComponentSchema: z.ZodType<SlabComponent> = baseComponentSchema.extend({
   children: z.lazy(() => z.array(SlabComponentSchema)).optional(),
 }) as any;

--- a/frontend/src/components/studio/DimensionLabel3D.tsx
+++ b/frontend/src/components/studio/DimensionLabel3D.tsx
@@ -98,12 +98,13 @@ const getEdgeGeometry = (
     }
 
     // When start and end points are the same, return an empty geometry to avoid fall-through.
+    // Drei's Line component requires at least 2 points to avoid negative typed array lengths.
     return {
       midpoint: [0, 0, 0],
       lineStart: [0, 0, 0],
       lineEnd: [0, 0, 0],
-      extensionA: [],
-      extensionB: [],
+      extensionA: [[0, 0, 0], [0, 0, 0]],
+      extensionB: [[0, 0, 0], [0, 0, 0]],
     };
   }
 

--- a/frontend/src/components/studio/DimensionLabel3D.tsx
+++ b/frontend/src/components/studio/DimensionLabel3D.tsx
@@ -17,6 +17,18 @@ interface DimensionLabel3DProps {
 }
 
 /**
+ * Evaluates a 3-component expression tuple into a THREE.Vector3.
+ */
+const evaluateVector = (
+  pos: [Expression, Expression, Expression],
+  vars: Record<string, number>
+): THREE.Vector3 => new THREE.Vector3(
+  evaluateExpression(pos[0], vars),
+  evaluateExpression(pos[1], vars),
+  evaluateExpression(pos[2], vars)
+);
+
+/**
  * Computes the midpoint position and extension line endpoints for a dimension label
  * based on which edge of the parent slab it is attached to.
  */
@@ -31,16 +43,8 @@ const getEdgeGeometry = (
 
   if (edge === 'custom' && startPos && endPos) {
     // Evaluate expressions to get absolute positions relative to the component
-    const startVector = new THREE.Vector3(
-      evaluateExpression(startPos[0] as Expression, variables),
-      evaluateExpression(startPos[1] as Expression, variables),
-      evaluateExpression(startPos[2] as Expression, variables)
-    );
-    const endVector = new THREE.Vector3(
-      evaluateExpression(endPos[0] as Expression, variables),
-      evaluateExpression(endPos[1] as Expression, variables),
-      evaluateExpression(endPos[2] as Expression, variables)
-    );
+    const startVector = evaluateVector(startPos as [Expression, Expression, Expression], variables);
+    const endVector = evaluateVector(endPos as [Expression, Expression, Expression], variables);
 
     const lineDir = new THREE.Vector3().subVectors(endVector, startVector);
     const length = lineDir.length();
@@ -51,11 +55,9 @@ const getEdgeGeometry = (
       let offsetVec = new THREE.Vector3();
 
       if (offsetDirection) {
-        offsetVec.set(
-          evaluateExpression(offsetDirection[0] as Expression, variables),
-          evaluateExpression(offsetDirection[1] as Expression, variables),
-          evaluateExpression(offsetDirection[2] as Expression, variables)
-        ).normalize().multiplyScalar(offset);
+        offsetVec = evaluateVector(offsetDirection as [Expression, Expression, Expression], variables)
+          .normalize()
+          .multiplyScalar(offset);
       } else {
         // Default offset calculation
         // Try to cross with Y axis. If line is vertical, cross with X axis.

--- a/frontend/src/components/studio/DimensionLabel3D.tsx
+++ b/frontend/src/components/studio/DimensionLabel3D.tsx
@@ -179,8 +179,11 @@ export const DimensionLabel3D: React.FC<DimensionLabel3DProps> = ({
     return getEdgeGeometry(label, parentLength, parentDepth, parentThickness, variables);
   }, [label, parentLength, parentDepth, parentThickness, variables]);
 
-  const lineColor = isSelected ? '#4f46e5' : '#6366f1';
-  const textColor = isSelected ? '#312e81' : '#1e1b4b';
+  const lineColor = isSelected ? '#f59e0b' : '#6366f1';
+  const textColor = isSelected ? '#78350f' : '#1e1b4b';
+  const bgColor = isSelected ? '#fef3c7' : 'white';
+  const mainLineWidth = isSelected ? 3 : 1.5;
+  const extLineWidth = isSelected ? 2 : 1;
 
   return (
     <group onClick={(e) => { e.stopPropagation(); onSelect(label.id); }}>
@@ -188,25 +191,25 @@ export const DimensionLabel3D: React.FC<DimensionLabel3DProps> = ({
       <Line
         points={[geometry.lineStart, geometry.lineEnd]}
         color={lineColor}
-        lineWidth={1.5}
+        lineWidth={mainLineWidth}
       />
 
       {/* Arrow heads (small triangles at each end) */}
       <Line
         points={[geometry.lineStart, geometry.lineEnd]}
         color={lineColor}
-        lineWidth={1.5}
+        lineWidth={mainLineWidth}
       />
 
       {/* Extension lines */}
-      <Line points={geometry.extensionA} color={lineColor} lineWidth={1} />
-      <Line points={geometry.extensionB} color={lineColor} lineWidth={1} />
+      <Line points={geometry.extensionA} color={lineColor} lineWidth={extLineWidth} />
+      <Line points={geometry.extensionB} color={lineColor} lineWidth={extLineWidth} />
 
       {/* Text label - always faces camera */}
       <Billboard position={geometry.midpoint} follow={true} lockX={false} lockY={false} lockZ={false}>
         <mesh position={[0, 0, -0.1]}>
           <planeGeometry args={[evaluatedText.length * 3.2 + 6, 7]} />
-          <meshBasicMaterial color="white" transparent opacity={0.9} depthTest={false} />
+          <meshBasicMaterial color={bgColor} transparent opacity={isSelected ? 1 : 0.9} depthTest={false} />
         </mesh>
         <Text
           fontSize={4}

--- a/frontend/src/components/studio/DimensionLabel3D.tsx
+++ b/frontend/src/components/studio/DimensionLabel3D.tsx
@@ -96,6 +96,15 @@ const getEdgeGeometry = (
         ]
       };
     }
+
+    // When start and end points are the same, return an empty geometry to avoid fall-through.
+    return {
+      midpoint: [0, 0, 0],
+      lineStart: [0, 0, 0],
+      lineEnd: [0, 0, 0],
+      extensionA: [],
+      extensionB: [],
+    };
   }
 
   // Default to top-front

--- a/frontend/src/components/studio/DimensionLabel3D.tsx
+++ b/frontend/src/components/studio/DimensionLabel3D.tsx
@@ -21,12 +21,81 @@ interface DimensionLabel3DProps {
  * based on which edge of the parent slab it is attached to.
  */
 const getEdgeGeometry = (
-  edge: string,
+  label: DimensionLabel,
   L: number,
   D: number,
   T: number,
-  offset: number,
+  variables: Record<string, number>,
 ): { midpoint: [number, number, number]; lineStart: [number, number, number]; lineEnd: [number, number, number]; extensionA: [number, number, number][]; extensionB: [number, number, number][] } => {
+  const { edge, offset = 15, startPos, endPos, offsetDirection } = label;
+
+  if (edge === 'custom' && startPos && endPos) {
+    // Evaluate expressions to get absolute positions relative to the component
+    const startVector = new THREE.Vector3(
+      evaluateExpression(startPos[0] as Expression, variables),
+      evaluateExpression(startPos[1] as Expression, variables),
+      evaluateExpression(startPos[2] as Expression, variables)
+    );
+    const endVector = new THREE.Vector3(
+      evaluateExpression(endPos[0] as Expression, variables),
+      evaluateExpression(endPos[1] as Expression, variables),
+      evaluateExpression(endPos[2] as Expression, variables)
+    );
+
+    const lineDir = new THREE.Vector3().subVectors(endVector, startVector);
+    const length = lineDir.length();
+
+    if (length > 0) {
+      lineDir.normalize();
+
+      let offsetVec = new THREE.Vector3();
+
+      if (offsetDirection) {
+        offsetVec.set(
+          evaluateExpression(offsetDirection[0] as Expression, variables),
+          evaluateExpression(offsetDirection[1] as Expression, variables),
+          evaluateExpression(offsetDirection[2] as Expression, variables)
+        ).normalize().multiplyScalar(offset);
+      } else {
+        // Default offset calculation
+        // Try to cross with Y axis. If line is vertical, cross with X axis.
+        const up = new THREE.Vector3(0, 1, 0);
+        if (Math.abs(lineDir.dot(up)) > 0.99) {
+          up.set(1, 0, 0);
+        }
+
+        offsetVec.crossVectors(lineDir, up).normalize().multiplyScalar(offset);
+
+        // For horizontal planes, we want the offset to go outward/upward.
+        if (lineDir.y === 0 && offsetVec.y === 0) {
+          offsetVec.set(0, offset, 0);
+        }
+      }
+
+      const lineStartVector = new THREE.Vector3().addVectors(startVector, offsetVec);
+      const lineEndVector = new THREE.Vector3().addVectors(endVector, offsetVec);
+      const midVector = new THREE.Vector3().addVectors(lineStartVector, lineEndVector).multiplyScalar(0.5);
+
+      // Extending slightly beyond the dimension line
+      const extDir = offsetVec.clone().normalize();
+      const extAmount = 3;
+
+      return {
+        midpoint: [midVector.x, midVector.y, midVector.z],
+        lineStart: [lineStartVector.x, lineStartVector.y, lineStartVector.z],
+        lineEnd: [lineEndVector.x, lineEndVector.y, lineEndVector.z],
+        extensionA: [
+          [startVector.x, startVector.y, startVector.z],
+          [lineStartVector.x + extDir.x * extAmount, lineStartVector.y + extDir.y * extAmount, lineStartVector.z + extDir.z * extAmount]
+        ],
+        extensionB: [
+          [endVector.x, endVector.y, endVector.z],
+          [lineEndVector.x + extDir.x * extAmount, lineEndVector.y + extDir.y * extAmount, lineEndVector.z + extDir.z * extAmount]
+        ]
+      };
+    }
+  }
+
   // Default to top-front
   let midpoint: [number, number, number] = [L / 2, T + offset, 0];
   let lineStart: [number, number, number] = [0, T + offset, 0];
@@ -96,8 +165,8 @@ export const DimensionLabel3D: React.FC<DimensionLabel3DProps> = ({
   }, [label.text, variables]);
 
   const geometry = useMemo(() => {
-    return getEdgeGeometry(label.edge, parentLength, parentDepth, parentThickness, label.offset);
-  }, [label.edge, parentLength, parentDepth, parentThickness, label.offset]);
+    return getEdgeGeometry(label, parentLength, parentDepth, parentThickness, variables);
+  }, [label, parentLength, parentDepth, parentThickness, variables]);
 
   const lineColor = isSelected ? '#4f46e5' : '#6366f1';
   const textColor = isSelected ? '#312e81' : '#1e1b4b';

--- a/frontend/src/components/studio/StoneForgeEditor.tsx
+++ b/frontend/src/components/studio/StoneForgeEditor.tsx
@@ -559,28 +559,43 @@ export const StoneForgeEditor = () => {
     return null;
   };
 
-  const handleAddDimensionLabel = () => {
+  const handleAddDimensionLabel = (isCustom: boolean = false) => {
     if (!selectedEdge) return;
     const { slabId, edge } = selectedEdge;
     const parent = findComponentDeep(template.components, slabId);
     if (!parent) return;
 
-    // Default text expression: use the dimension that the edge measures
-    const isXEdge = edge.includes('front') || edge.includes('back');
-    const isZEdge = edge.includes('left') || edge.includes('right');
-    const isVertical = !edge.includes('top') && !edge.includes('bottom');
-    let defaultText: Expression = parent.length;
-    if (isZEdge) defaultText = parent.depth;
-    if (isVertical) defaultText = parent.thickness;
+    let newLabel: DimensionLabel;
 
-    const newLabel: DimensionLabel = {
-      id: `dim_${Date.now()}`,
-      type: 'dimension_label',
-      name: `${edge} Dimension`,
-      edge: edge,
-      text: defaultText,
-      offset: 15,
-    };
+    if (isCustom) {
+      newLabel = {
+        id: `dim_${Date.now()}`,
+        type: 'dimension_label',
+        name: `Custom Dimension`,
+        edge: 'custom',
+        text: '0',
+        offset: 15,
+        startPos: [0, 0, 0],
+        endPos: [parent.length, 0, 0],
+      };
+    } else {
+      // Default text expression: use the dimension that the edge measures
+      const isXEdge = edge.includes('front') || edge.includes('back');
+      const isZEdge = edge.includes('left') || edge.includes('right');
+      const isVertical = !edge.includes('top') && !edge.includes('bottom');
+      let defaultText: Expression = parent.length;
+      if (isZEdge) defaultText = parent.depth;
+      if (isVertical) defaultText = parent.thickness;
+
+      newLabel = {
+        id: `dim_${Date.now()}`,
+        type: 'dimension_label',
+        name: `${edge} Dimension`,
+        edge: edge,
+        text: defaultText,
+        offset: 15,
+      };
+    }
 
     setTemplate(prev => ({
       ...prev,
@@ -977,8 +992,12 @@ export const StoneForgeEditor = () => {
                           <span>Add Custom Component</span>
                           <Plus className="w-3.5 h-3.5 text-indigo-500" />
                         </button>
-                        <button onClick={handleAddDimensionLabel} className="text-xs bg-amber-50 hover:bg-amber-100 text-amber-700 py-2 px-3 rounded border border-amber-200 text-left flex items-center justify-between mt-2">
+                        <button onClick={() => handleAddDimensionLabel()} className="text-xs bg-amber-50 hover:bg-amber-100 text-amber-700 py-2 px-3 rounded border border-amber-200 text-left flex items-center justify-between mt-2">
                           <span>Add Dimension Label</span>
+                          <Ruler className="w-3.5 h-3.5 text-amber-500" />
+                        </button>
+                        <button onClick={() => handleAddDimensionLabel(true)} className="text-xs bg-amber-50 hover:bg-amber-100 text-amber-700 py-2 px-3 rounded border border-amber-200 text-left flex items-center justify-between">
+                          <span>Add Custom Dimension</span>
                           <Ruler className="w-3.5 h-3.5 text-amber-500" />
                         </button>
                       </div>

--- a/frontend/src/components/studio/StoneForgeEditor.tsx
+++ b/frontend/src/components/studio/StoneForgeEditor.tsx
@@ -996,7 +996,7 @@ export const StoneForgeEditor = () => {
                           <span>Add Dimension Label</span>
                           <Ruler className="w-3.5 h-3.5 text-amber-500" />
                         </button>
-                        <button onClick={() => handleAddDimensionLabel(true)} className="text-xs bg-amber-50 hover:bg-amber-100 text-amber-700 py-2 px-3 rounded border border-amber-200 text-left flex items-center justify-between">
+                        <button onClick={() => handleAddDimensionLabel(true)} className="text-xs bg-amber-50 hover:bg-amber-100 text-amber-700 py-2 px-3 rounded border border-amber-200 text-left flex items-center justify-between mt-2">
                           <span>Add Custom Dimension</span>
                           <Ruler className="w-3.5 h-3.5 text-amber-500" />
                         </button>
@@ -1044,6 +1044,49 @@ export const StoneForgeEditor = () => {
                         className="w-full text-sm border border-gray-300 rounded-md px-2 py-1.5 focus:ring-1 focus:ring-amber-500 focus:border-amber-500"
                       />
                     </div>
+                    {selectedDimLabel.label.edge === 'custom' && (
+                      <div className="pt-4 border-t border-gray-100">
+                        <h4 className="text-xs font-semibold text-gray-900 mb-3">Custom Points</h4>
+
+                        <div className="mb-3">
+                          <label className="block text-[10px] font-medium text-gray-500 mb-1">Start Pos (X, Y, Z)</label>
+                          <div className="grid grid-cols-3 gap-2">
+                            {['X', 'Y', 'Z'].map((axis, i) => (
+                              <input
+                                key={`start-${axis}`}
+                                type="text"
+                                value={selectedDimLabel.label.startPos?.[i] ?? 0}
+                                onChange={(e) => {
+                                  const newPos = [...(selectedDimLabel.label.startPos || [0,0,0])] as [Expression, Expression, Expression];
+                                  newPos[i] = e.target.value;
+                                  handleUpdateDimensionLabel(selectedDimLabel.slabId, selectedDimLabel.label.id, 'startPos', newPos);
+                                }}
+                                className="w-full text-xs border border-gray-300 rounded px-2 py-1"
+                              />
+                            ))}
+                          </div>
+                        </div>
+
+                        <div>
+                          <label className="block text-[10px] font-medium text-gray-500 mb-1">End Pos (X, Y, Z)</label>
+                          <div className="grid grid-cols-3 gap-2">
+                            {['X', 'Y', 'Z'].map((axis, i) => (
+                              <input
+                                key={`end-${axis}`}
+                                type="text"
+                                value={selectedDimLabel.label.endPos?.[i] ?? 0}
+                                onChange={(e) => {
+                                  const newPos = [...(selectedDimLabel.label.endPos || [0,0,0])] as [Expression, Expression, Expression];
+                                  newPos[i] = e.target.value;
+                                  handleUpdateDimensionLabel(selectedDimLabel.slabId, selectedDimLabel.label.id, 'endPos', newPos);
+                                }}
+                                className="w-full text-xs border border-gray-300 rounded px-2 py-1"
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    )}
                     <div className="pt-4 border-t border-gray-100">
                       <button
                         onClick={() => handleRemoveDimensionLabel(selectedDimLabel.slabId, selectedDimLabel.label.id)}


### PR DESCRIPTION
Allows users to define custom dimension lines not strictly bound to the slab parent dimensions but based on arbitrary expression coordinates and directional offsets.

---
*PR created automatically by Jules for task [6292165959980226480](https://jules.google.com/task/6292165959980226480) started by @jhoncr*