### PR TITLE
feat: Template Gallery Integration with Immutable Estimate Items

### DIFF
--- a/backend/functions/src/common/schemas/estimate_schema.ts
+++ b/backend/functions/src/common/schemas/estimate_schema.ts
@@ -1,5 +1,14 @@
 import * as z from "zod";
 import { contactInfoSchema, allowedCurrencySchema } from "./common_schemas";
+import { AssemblyTemplateSchema } from "./studio";
+
+// Define the schema for the attached template snapshot
+export const attachedTemplateSchema = z.object({
+  sourceTemplateId: z.string(), // Keep a reference just in case we want to show "Based on: [Name]"
+  snapshot: AssemblyTemplateSchema, // The deep copy of the template structure
+  variableOverrides: z.record(z.string(), z.number()).optional(), // User's variable changes
+});
+export type AttachedTemplate = z.infer<typeof attachedTemplateSchema>;
 
 export const currencyCodeSchema = allowedCurrencySchema; // ISO 4217 currency codes are 3 letters
 // Add this near the top of the file, before the schemas
@@ -58,6 +67,9 @@ export const lineItemSchema = z.object({
       message: "A max of 254 characters is allowed in the description.",
     }),
   material: materialSchema,
+
+  // Optional attached template snapshot
+  attachedTemplate: attachedTemplateSchema.optional().nullable(),
 });
 
 export const adjustmentSchema = z.object({

--- a/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/NewItemForm.tsx
+++ b/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/NewItemForm.tsx
@@ -44,6 +44,13 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { TemplateGalleryModal } from "./TemplateGalleryModal";
+import { DBentry } from "@/lib/custom_types";
+import { AssemblyTemplate } from "@backend/common/schemas/studio";
+import { AttachedTemplate } from "@backend/common/schemas/estimate_schema";
+import { StoneForgeViewer } from "@/components/studio/StoneForgeViewer";
+import { StoneForgeVariableEditor } from "@/components/studio/StoneForgeVariableEditor";
+import { useParams, useSearchParams } from "next/navigation";
 
 interface NewItemFormProps {
   onAddItem: (items: LineItem[]) => Promise<boolean>; // Expects a promise now
@@ -128,6 +135,7 @@ const defaultFormValues: ItemFormValues = {
   laborRate: 0,
 };
 
+
 export function NewItemForm({
   onAddItem,
   currency,
@@ -142,6 +150,11 @@ export function NewItemForm({
   const [isOpen, setIsOpen] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 1340px)");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const journalId = (params?.journalId as string) || searchParams?.get("jid") || "";
+
+  const [attachedTemplate, setAttachedTemplate] = useState<AttachedTemplate | null>(null);
 
   const canAdd = useMemo(() => ROLES_THAT_ADD.has(userRole), [userRole]);
 
@@ -254,9 +267,11 @@ export function NewItemForm({
     if (editingItem && editingItem.parentId === "root") {
       const formValues = populateFormFromLineItem(editingItem);
       form.reset(formValues);
+      setAttachedTemplate(editingItem.attachedTemplate || null);
       setIsOpen(true); // Open dialog on mobile
     } else if (!editingItem) {
       form.reset(defaultFormValues);
+      setAttachedTemplate(null);
       setIsOpen(false); // Close dialog when not editing
     }
   }, [editingItem, form, populateFormFromLineItem]);
@@ -354,9 +369,10 @@ export function NewItemForm({
           currency: currency,
           labor: null,
         },
+        attachedTemplate: attachedTemplate,
       };
     },
-    [currency, editingItem],
+    [currency, editingItem, attachedTemplate],
   );
 
   const createLaborItem = useCallback(
@@ -447,6 +463,7 @@ export function NewItemForm({
 
       if (success) {
         form.reset(defaultFormValues);
+        setAttachedTemplate(null);
         setIsOpen(false);
         if (editingItem && onCancelEdit) {
           onCancelEdit(); // Clear editing state
@@ -459,6 +476,53 @@ export function NewItemForm({
       setIsSubmitting(false);
     }
   };
+
+  const handleSelectTemplate = (templateEntry: DBentry) => {
+    const templateDetails = templateEntry.details as AssemblyTemplate;
+
+    const newAttachedTemplate: AttachedTemplate = {
+      sourceTemplateId: templateEntry.id,
+      snapshot: JSON.parse(JSON.stringify(templateDetails)), // deep copy
+      variableOverrides: {},
+    };
+
+    setAttachedTemplate(newAttachedTemplate);
+    form.setValue("description", `Custom ${templateDetails.name}`);
+    form.setValue("quantity", 1);
+    setIsOpen(true);
+  };
+
+  const handleVariableChange = (variableId: string, newValue: number) => {
+    if (!attachedTemplate) return;
+
+    setAttachedTemplate({
+      ...attachedTemplate,
+      variableOverrides: {
+        ...(attachedTemplate.variableOverrides || {}),
+        [variableId]: newValue
+      }
+    });
+  };
+
+  const mergedVariables = useMemo(() => {
+    if (!attachedTemplate) return {};
+
+    const merged: Record<string, number> = {};
+    attachedTemplate.snapshot.variables.forEach(v => {
+      if (v.label) {
+        merged[v.label] = v.default;
+      }
+    });
+
+    Object.entries(attachedTemplate.variableOverrides || {}).forEach(([id, value]) => {
+      const variable = attachedTemplate.snapshot.variables.find(v => v.id === id);
+      if (variable && variable.label) {
+        merged[variable.label] = value;
+      }
+    });
+
+    return merged;
+  }, [attachedTemplate]);
 
   const formContent = (
     <Form {...form}>
@@ -808,29 +872,72 @@ export function NewItemForm({
     </Form>
   );
 
+  const combinedContent = attachedTemplate ? (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 h-full min-h-[500px]">
+      <div className="flex flex-col border-r pr-4 h-full">
+        <div className="flex-1 min-h-[300px] bg-secondary/20 rounded-md overflow-hidden border mb-4">
+          <StoneForgeViewer
+            components={attachedTemplate.snapshot.components}
+            variables={mergedVariables}
+          />
+        </div>
+        <div className="flex-1 bg-white rounded-md border overflow-hidden">
+          <StoneForgeVariableEditor
+            template={attachedTemplate.snapshot}
+            overrides={attachedTemplate.variableOverrides}
+            onVariableChange={handleVariableChange}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col h-full">
+        {formContent}
+      </div>
+    </div>
+  ) : (
+    <div className="flex-grow overflow-y-auto pr-2">{formContent}</div>
+  );
+
   if (isDesktop) {
     return (
       <div
         id="estimate-add-item-form"
-        className="print:hidden fixed bottom-4 right-4 z-50 bg-background border rounded-lg p-4 w-[400px] shadow-lg max-h-[calc(100vh-4rem)] flex flex-col"
+        className={`print:hidden fixed bottom-4 right-4 z-50 bg-background border rounded-lg p-4 shadow-lg max-h-[calc(100vh-4rem)] flex flex-col ${attachedTemplate ? 'w-[800px] xl:w-[1000px]' : 'w-[400px]'}`}
       >
         <div className="mb-4 flex-shrink-0">
           <h3 className="text-lg font-semibold">
             {editingItem ? t("editItem") : t("title")}
           </h3>
         </div>
-        <div className="flex-grow overflow-y-auto pr-2">{formContent}</div>
+        <div className="flex-grow overflow-y-auto pr-2">{combinedContent}</div>
         <div className="flex justify-end gap-2 mt-4 flex-shrink-0">
+          {!editingItem && !attachedTemplate && (
+            <div className="mr-auto">
+              <TemplateGalleryModal journalId={journalId} onSelectTemplate={handleSelectTemplate} disabled={!canAdd} />
+            </div>
+          )}
           {editingItem && onCancelEdit && (
             <Button
               type="button"
               variant="outline"
               onClick={() => {
                 form.reset(defaultFormValues);
+                setAttachedTemplate(null);
                 onCancelEdit();
               }}
             >
               {t("cancel")}
+            </Button>
+          )}
+          {!editingItem && attachedTemplate && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                form.reset(defaultFormValues);
+                setAttachedTemplate(null);
+              }}
+            >
+              Clear Template
             </Button>
           )}
           <Button
@@ -871,27 +978,51 @@ export function NewItemForm({
           }
         }}
       >
-        <DialogTrigger asChild>
-          <Button
-            size="sm"
-            className="w-full gap-2 print:hidden"
-            variant={"brutalist"}
-            disabled={!canAdd}
-            title={!canAdd ? t("permissionDenied") : ""}
-          >
-            <PackagePlus size={16} /> {t("title")}
-          </Button>
-        </DialogTrigger>
-        <DialogContent className="max-w-md max-h-[90vh] flex flex-col overflow-hidden">
+        {!editingItem && (
+          <div className="flex gap-2 w-full">
+            <DialogTrigger asChild>
+              <Button
+                size="sm"
+                className="w-full gap-2 print:hidden"
+                variant={"brutalist"}
+                disabled={!canAdd}
+                title={!canAdd ? t("permissionDenied") : ""}
+              >
+                <PackagePlus size={16} /> {t("title")}
+              </Button>
+            </DialogTrigger>
+            <div className="w-full">
+              <TemplateGalleryModal journalId={journalId} onSelectTemplate={handleSelectTemplate} disabled={!canAdd} />
+            </div>
+          </div>
+        )}
+        <DialogContent className={`${attachedTemplate ? 'max-w-4xl max-h-[90vh]' : 'max-w-md max-h-[90vh]'} flex flex-col overflow-hidden`}>
           <DialogHeader className="flex-shrink-0">
             <DialogTitle>
               {editingItem ? t("editItem") : t("title")}
             </DialogTitle>
           </DialogHeader>
-          <div className="flex-grow overflow-y-auto pr-2">{formContent}</div>
-          <DialogFooter className="pt-4 flex flex-row -shrink-0 gap-2">
+          <div className="flex-grow overflow-y-auto pr-2">{combinedContent}</div>
+          <DialogFooter className="pt-4 flex flex-row shrink-0 gap-2">
+            {attachedTemplate && !editingItem && (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() => {
+                  form.reset(defaultFormValues);
+                  setAttachedTemplate(null);
+                }}
+              >
+                Clear Template
+              </Button>
+            )}
             <DialogClose asChild>
-              <Button variant="outline" className="w-full">
+              <Button variant="outline" className="w-full" onClick={() => {
+                if (editingItem && onCancelEdit) {
+                  onCancelEdit();
+                }
+              }}>
                 {editingItem ? t("cancel") : tCommon("cancel")}
               </Button>
             </DialogClose>

--- a/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/NewItemForm.tsx
+++ b/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/NewItemForm.tsx
@@ -887,18 +887,18 @@ export function NewItemForm({
   );
 
   const combinedContent = attachedTemplate ? (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 h-full min-h-[600px]">
-      {/* LEFT PANE: Form & Variables */}
-      <div className="flex flex-col h-full overflow-hidden border-r pr-2">
-        {formContent}
-      </div>
-
-      {/* RIGHT PANE: 3D Viewer */}
+    <div className="grid grid-cols-1 md:grid-cols-[3fr_2fr] lg:grid-cols-[2fr_1fr] gap-6 h-full min-h-[600px]">
+      {/* LEFT PANE: 3D Viewer (Maximized Real Estate) */}
       <div className="flex flex-col h-full bg-secondary/20 rounded-md overflow-hidden border relative min-h-[400px]">
         <StoneForgeViewer
           components={attachedTemplate.snapshot.components}
           variables={mergedVariables}
         />
+      </div>
+
+      {/* RIGHT PANE: Form & Variables */}
+      <div className="flex flex-col h-full overflow-hidden border-l pl-2">
+        {formContent}
       </div>
     </div>
   ) : (
@@ -909,7 +909,7 @@ export function NewItemForm({
     return (
       <div
         id="estimate-add-item-form"
-        className={`print:hidden fixed bottom-4 right-4 z-50 bg-background border rounded-lg p-4 shadow-lg max-h-[calc(100vh-4rem)] flex flex-col ${attachedTemplate ? 'w-[90vw] max-w-5xl' : 'w-[400px]'}`}
+        className={`print:hidden fixed bottom-4 right-4 z-50 bg-background border rounded-lg p-4 shadow-lg max-h-[calc(100vh-4rem)] flex flex-col ${attachedTemplate ? 'w-[95vw] max-w-7xl' : 'w-[400px]'}`}
       >
         <div className="mb-4 flex-shrink-0">
           <h3 className="text-lg font-semibold">
@@ -1004,7 +1004,7 @@ export function NewItemForm({
             </div>
           </div>
         )}
-        <DialogContent className={`${attachedTemplate ? 'max-w-[90vw] xl:max-w-5xl max-h-[90vh]' : 'max-w-md max-h-[90vh]'} flex flex-col overflow-hidden`}>
+        <DialogContent className={`${attachedTemplate ? 'max-w-[95vw] xl:max-w-7xl max-h-[90vh]' : 'max-w-md max-h-[90vh]'} flex flex-col overflow-hidden`}>
           <DialogHeader className="flex-shrink-0">
             <DialogTitle>
               {editingItem ? t("editItem") : t("title")}

--- a/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/NewItemForm.tsx
+++ b/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/NewItemForm.tsx
@@ -551,30 +551,57 @@ export function NewItemForm({
           )}
         />
 
-        <FormField
-          control={form.control}
-          name="unitPrice"
-          render={({ field }) => (
-            <FormItem className="space-y-0 mt-2">
-              <FormLabel>{t("unitPrice")}</FormLabel>
-              <FormControl>
-                <NumericInput
-                  value={field.value.toString()}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    const value = e.target.value;
-                    field.onChange(Number.parseFloat(value) || 0);
-                  }}
-                  prefix={currencyToSymbol(currency || "")}
-                  placeholder="0.00"
-                  className="peer text-center"
-                  disabled={!canAdd}
-                  aria-label={t("unitPrice")}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="unitPrice"
+            render={({ field }) => (
+              <FormItem className="space-y-0 mt-2">
+                <FormLabel>{t("unitPrice")}</FormLabel>
+                <FormControl>
+                  <NumericInput
+                    value={field.value.toString()}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      const value = e.target.value;
+                      field.onChange(Number.parseFloat(value) || 0);
+                    }}
+                    prefix={currencyToSymbol(currency || "")}
+                    placeholder="0.00"
+                    className="peer text-center"
+                    disabled={!canAdd}
+                    aria-label={t("unitPrice")}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {!form.watch("dimensionType").startsWith("area") && (
+            <FormField
+              control={form.control}
+              name="quantity"
+              render={({ field }) => (
+                <FormItem className="space-y-0 mt-2">
+                  <FormLabel>{t("quantity")}</FormLabel>
+                  <FormControl>
+                    <NumericInput
+                      className="peer text-center"
+                      value={field.value.toString()}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        const value = Number(e.target.value);
+                        field.onChange(value >= 0 ? value : 0);
+                      }}
+                      disabled={!canAdd}
+                      aria-label={t("quantity")}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           )}
-        />
+        </div>
 
         <FormField
           control={form.control}
@@ -710,30 +737,6 @@ export function NewItemForm({
           </div>
         )}
 
-        {!form.watch("dimensionType").startsWith("area") && (
-          <FormField
-            control={form.control}
-            name="quantity"
-            render={({ field }) => (
-              <FormItem className="space-y-0 mt-2">
-                <FormLabel>{t("quantity")}</FormLabel>
-                <FormControl>
-                  <NumericInput
-                    className="peer text-center"
-                    value={field.value.toString()}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      const value = Number(e.target.value);
-                      field.onChange(value >= 0 ? value : 0);
-                    }}
-                    disabled={!canAdd}
-                    aria-label={t("quantity")}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        )}
         <div className="text-right text-sm font-medium text-muted-foreground mt-0">
           {form.watch("quantity")}{" "}
           {form.watch("dimensionType").split("-")[1] || ""}
@@ -854,6 +857,17 @@ export function NewItemForm({
           )}
         />
 
+        {attachedTemplate && (
+          <div className="mt-6 mb-2 border rounded-md overflow-hidden bg-white shadow-sm">
+            <StoneForgeVariableEditor
+              template={attachedTemplate.snapshot}
+              overrides={attachedTemplate.variableOverrides}
+              onVariableChange={handleVariableChange}
+              scrollable={false}
+            />
+          </div>
+        )}
+
         <div className="text-sm font-semibold text-right mt-auto pt-4 border-t">
           <div className="flex justify-between">
             <span>{t("material")}:</span>
@@ -873,24 +887,18 @@ export function NewItemForm({
   );
 
   const combinedContent = attachedTemplate ? (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 h-full min-h-[500px]">
-      <div className="flex flex-col border-r pr-4 h-full">
-        <div className="flex-1 min-h-[300px] bg-secondary/20 rounded-md overflow-hidden border mb-4">
-          <StoneForgeViewer
-            components={attachedTemplate.snapshot.components}
-            variables={mergedVariables}
-          />
-        </div>
-        <div className="flex-1 bg-white rounded-md border overflow-hidden">
-          <StoneForgeVariableEditor
-            template={attachedTemplate.snapshot}
-            overrides={attachedTemplate.variableOverrides}
-            onVariableChange={handleVariableChange}
-          />
-        </div>
-      </div>
-      <div className="flex flex-col h-full">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 h-full min-h-[600px]">
+      {/* LEFT PANE: Form & Variables */}
+      <div className="flex flex-col h-full overflow-hidden border-r pr-2">
         {formContent}
+      </div>
+
+      {/* RIGHT PANE: 3D Viewer */}
+      <div className="flex flex-col h-full bg-secondary/20 rounded-md overflow-hidden border relative min-h-[400px]">
+        <StoneForgeViewer
+          components={attachedTemplate.snapshot.components}
+          variables={mergedVariables}
+        />
       </div>
     </div>
   ) : (
@@ -901,7 +909,7 @@ export function NewItemForm({
     return (
       <div
         id="estimate-add-item-form"
-        className={`print:hidden fixed bottom-4 right-4 z-50 bg-background border rounded-lg p-4 shadow-lg max-h-[calc(100vh-4rem)] flex flex-col ${attachedTemplate ? 'w-[800px] xl:w-[1000px]' : 'w-[400px]'}`}
+        className={`print:hidden fixed bottom-4 right-4 z-50 bg-background border rounded-lg p-4 shadow-lg max-h-[calc(100vh-4rem)] flex flex-col ${attachedTemplate ? 'w-[90vw] max-w-5xl' : 'w-[400px]'}`}
       >
         <div className="mb-4 flex-shrink-0">
           <h3 className="text-lg font-semibold">
@@ -996,7 +1004,7 @@ export function NewItemForm({
             </div>
           </div>
         )}
-        <DialogContent className={`${attachedTemplate ? 'max-w-4xl max-h-[90vh]' : 'max-w-md max-h-[90vh]'} flex flex-col overflow-hidden`}>
+        <DialogContent className={`${attachedTemplate ? 'max-w-[90vw] xl:max-w-5xl max-h-[90vh]' : 'max-w-md max-h-[90vh]'} flex flex-col overflow-hidden`}>
           <DialogHeader className="flex-shrink-0">
             <DialogTitle>
               {editingItem ? t("editItem") : t("title")}

--- a/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/TemplateGalleryModal.tsx
+++ b/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/TemplateGalleryModal.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Box, Loader2 } from "lucide-react";
+import { useFetchEntries } from "../../../comp/useFetch";
+import { AssemblyTemplate } from "@backend/common/schemas/studio";
+import { DBentry } from "@/lib/custom_types";
+
+interface TemplateGalleryModalProps {
+  journalId: string;
+  onSelectTemplate: (templateEntry: DBentry) => void;
+  disabled?: boolean;
+}
+
+export function TemplateGalleryModal({ journalId, onSelectTemplate, disabled }: TemplateGalleryModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { list: templates, loading, error } = useFetchEntries(journalId, "template");
+
+  const handleSelect = (templateEntry: DBentry) => {
+    onSelectTemplate(templateEntry);
+    setIsOpen(false);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={disabled}
+          className="w-full gap-2"
+        >
+          <Box size={16} /> Add from Gallery
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Template Gallery</DialogTitle>
+        </DialogHeader>
+        <div className="flex-1 overflow-y-auto p-4">
+          {loading ? (
+            <div className="flex justify-center items-center h-40">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : error ? (
+            <div className="text-center text-red-500 py-8">
+              Failed to load templates: {error}
+            </div>
+          ) : templates.length === 0 ? (
+            <div className="text-center text-muted-foreground py-12">
+              <Box className="h-12 w-12 mx-auto mb-4 opacity-20" />
+              <p>No templates found in this journal.</p>
+              <p className="text-sm mt-2">Go to the Journal to create your first template.</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+              {templates.map((templateEntry) => {
+                const template = templateEntry.details as AssemblyTemplate;
+                return (
+                  <div
+                    key={templateEntry.id}
+                    className="border rounded-lg p-4 cursor-pointer hover:border-primary hover:bg-accent/50 transition-colors flex flex-col group"
+                    onClick={() => handleSelect(templateEntry)}
+                  >
+                    <div className="bg-secondary/30 rounded-md h-32 mb-3 flex items-center justify-center">
+                       {/* Placeholder for a potential 3D preview thumbnail */}
+                       <Box className="h-10 w-10 text-muted-foreground/40 group-hover:text-primary/40 transition-colors" />
+                    </div>
+                    <h3 className="font-semibold text-sm truncate" title={template.name || templateEntry.name}>
+                      {template.name || templateEntry.name || "Untitled Template"}
+                    </h3>
+                    <div className="flex justify-between items-center mt-auto pt-2">
+                       <span className="text-xs text-muted-foreground">
+                         {template.components?.length || 0} component(s)
+                       </span>
+                       <Button size="sm" variant="secondary" className="h-7 text-xs">
+                         Select
+                       </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <DialogFooter className="sm:justify-start">
+          <DialogClose asChild>
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/studio/StoneForgeEditor.tsx
+++ b/frontend/src/components/studio/StoneForgeEditor.tsx
@@ -1075,7 +1075,7 @@ export const StoneForgeEditor = () => {
                               <input
                                 key={`start-${axis}`}
                                 type="text"
-                                value={selectedDimLabel.label.startPos?.[i] ?? 0}
+                                value={String(selectedDimLabel.label.startPos?.[i] ?? 0)}
                                 onChange={(e) => {
                                   const newPos = [...(selectedDimLabel.label.startPos || [0,0,0])] as [Expression, Expression, Expression];
                                   newPos[i] = e.target.value;
@@ -1094,7 +1094,7 @@ export const StoneForgeEditor = () => {
                               <input
                                 key={`end-${axis}`}
                                 type="text"
-                                value={selectedDimLabel.label.endPos?.[i] ?? 0}
+                                value={String(selectedDimLabel.label.endPos?.[i] ?? 0)}
                                 onChange={(e) => {
                                   const newPos = [...(selectedDimLabel.label.endPos || [0,0,0])] as [Expression, Expression, Expression];
                                   newPos[i] = e.target.value;
@@ -1133,7 +1133,7 @@ export const StoneForgeEditor = () => {
                         <label className="block text-xs font-medium text-gray-700 mb-1">Length (X)</label>
                         <input
                           type="text"
-                          value={selectedComponent.length}
+                          value={String(selectedComponent.length)}
                           onChange={(e) => handleComponentChange(selectedComponent.id, 'length', e.target.value)}
                           className="w-full text-sm border border-gray-300 rounded-md px-2 py-1.5"
                         />
@@ -1142,7 +1142,7 @@ export const StoneForgeEditor = () => {
                         <label className="block text-xs font-medium text-gray-700 mb-1">Thickness (Y)</label>
                         <input
                           type="text"
-                          value={selectedComponent.thickness}
+                          value={String(selectedComponent.thickness)}
                           onChange={(e) => handleComponentChange(selectedComponent.id, 'thickness', e.target.value)}
                           className="w-full text-sm border border-gray-300 rounded-md px-2 py-1.5"
                         />
@@ -1151,7 +1151,7 @@ export const StoneForgeEditor = () => {
                         <label className="block text-xs font-medium text-gray-700 mb-1">Depth (Z)</label>
                         <input
                           type="text"
-                          value={selectedComponent.depth}
+                          value={String(selectedComponent.depth)}
                           onChange={(e) => handleComponentChange(selectedComponent.id, 'depth', e.target.value)}
                           className="w-full text-sm border border-gray-300 rounded-md px-2 py-1.5"
                         />
@@ -1166,7 +1166,7 @@ export const StoneForgeEditor = () => {
                             <label className="block text-[10px] font-medium text-gray-500 mb-1">{axis}</label>
                             <input
                               type="text"
-                              value={selectedComponent.position[i as 0 | 1 | 2]}
+                              value={String(selectedComponent.position[i as 0 | 1 | 2])}
                               onChange={(e) => {
                                 const newPos = [...selectedComponent.position] as [Expression, Expression, Expression];
                                 newPos[i] = e.target.value;
@@ -1187,7 +1187,7 @@ export const StoneForgeEditor = () => {
                             <label className="block text-[10px] font-medium text-gray-500 mb-1">{axis}</label>
                             <input
                               type="text"
-                              value={selectedComponent.rotation?.[i as 0 | 1 | 2] || 0}
+                              value={String(selectedComponent.rotation?.[i as 0 | 1 | 2] || 0)}
                               onChange={(e) => {
                                 const newRot = [...(selectedComponent.rotation || [0, 0, 0])] as [Expression, Expression, Expression];
                                 newRot[i] = e.target.value;
@@ -1238,7 +1238,7 @@ export const StoneForgeEditor = () => {
                                 <label className="block text-[10px] text-gray-500 mb-1">Center X (from Left)</label>
                                 <input
                                   type="text"
-                                  value={cutout.centerX}
+                                  value={String(cutout.centerX)}
                                   onChange={(e) => handleUpdateCutout(selectedComponent.id, cutout.id, 'centerX', e.target.value)}
                                   className="w-full text-xs border border-gray-300 rounded px-2 py-1"
                                 />
@@ -1247,7 +1247,7 @@ export const StoneForgeEditor = () => {
                                 <label className="block text-[10px] text-gray-500 mb-1">Center Y (from Front)</label>
                                 <input
                                   type="text"
-                                  value={cutout.centerY}
+                                  value={String(cutout.centerY)}
                                   onChange={(e) => handleUpdateCutout(selectedComponent.id, cutout.id, 'centerY', e.target.value)}
                                   className="w-full text-xs border border-gray-300 rounded px-2 py-1"
                                 />
@@ -1261,7 +1261,7 @@ export const StoneForgeEditor = () => {
                                 </label>
                                 <input
                                   type="text"
-                                  value={cutout.width}
+                                  value={String(cutout.width)}
                                   onChange={(e) => handleUpdateCutout(selectedComponent.id, cutout.id, 'width', e.target.value)}
                                   className="w-full text-xs border border-gray-300 rounded px-2 py-1"
                                 />
@@ -1271,7 +1271,7 @@ export const StoneForgeEditor = () => {
                                   <label className="block text-[10px] text-gray-500 mb-1">Depth</label>
                                   <input
                                     type="text"
-                                    value={cutout.depth}
+                                    value={String(cutout.depth)}
                                     onChange={(e) => handleUpdateCutout(selectedComponent.id, cutout.id, 'depth', e.target.value)}
                                     className="w-full text-xs border border-gray-300 rounded px-2 py-1"
                                   />

--- a/frontend/src/components/studio/StoneForgeVariableEditor.tsx
+++ b/frontend/src/components/studio/StoneForgeVariableEditor.tsx
@@ -8,6 +8,7 @@ interface StoneForgeVariableEditorProps {
   template: AssemblyTemplate;
   overrides?: Record<string, number>;
   onVariableChange: (id: string, value: number) => void;
+  scrollable?: boolean;
 }
 
 /** Converts `snake_case` or `camelCase` labels into a friendly "Title Case" label. */
@@ -22,12 +23,13 @@ export const StoneForgeVariableEditor = ({
   template,
   overrides = {},
   onVariableChange,
+  scrollable = true,
 }: StoneForgeVariableEditorProps) => {
   const variables = template.variables;
 
   if (variables.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-center px-6 py-12 gap-3">
+      <div className={`flex flex-col items-center justify-center text-center px-6 py-12 gap-3 ${scrollable ? 'h-full' : ''}`}>
         <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center">
           <Ruler className="w-5 h-5 text-gray-400" />
         </div>
@@ -41,7 +43,7 @@ export const StoneForgeVariableEditor = ({
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className={`flex flex-col ${scrollable ? 'h-full' : 'w-full'}`}>
       {/* Header */}
       <div className="p-4 border-b border-gray-100 bg-gray-50">
         <h3 className="text-xs font-bold uppercase tracking-wider text-gray-500 flex items-center gap-1.5">
@@ -53,7 +55,7 @@ export const StoneForgeVariableEditor = ({
       </div>
 
       {/* Variable List */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className={`${scrollable ? 'flex-1 overflow-y-auto' : ''} p-4 space-y-4`}>
         {variables.map((v) => (
           <div key={v.id} className="group">
             <label

--- a/frontend/src/components/studio/StoneForgeVariableEditor.tsx
+++ b/frontend/src/components/studio/StoneForgeVariableEditor.tsx
@@ -6,6 +6,7 @@ import { Ruler, Info } from 'lucide-react';
 
 interface StoneForgeVariableEditorProps {
   template: AssemblyTemplate;
+  overrides?: Record<string, number>;
   onVariableChange: (id: string, value: number) => void;
 }
 
@@ -19,6 +20,7 @@ function humanizeLabel(label: string): string {
 
 export const StoneForgeVariableEditor = ({
   template,
+  overrides = {},
   onVariableChange,
 }: StoneForgeVariableEditorProps) => {
   const variables = template.variables;
@@ -64,7 +66,7 @@ export const StoneForgeVariableEditor = ({
               <input
                 id={`var-${v.id}`}
                 type="number"
-                value={v.default}
+                value={overrides[v.id] !== undefined ? overrides[v.id] : v.default}
                 step="0.1"
                 onChange={(e) =>
                   onVariableChange(v.id, parseFloat(e.target.value) || 0)

--- a/frontend/src/components/studio/StoneForgeViewer.tsx
+++ b/frontend/src/components/studio/StoneForgeViewer.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, Environment, Grid } from '@react-three/drei';
+import { SlabComponent } from "@backend/common/schemas/studio";
+import { evaluateExpression } from '../../lib/evaluator';
+import { Slab3D } from './Slab3D';
+
+interface StoneForgeViewerProps {
+  components: SlabComponent[];
+  variables: Record<string, number>;
+}
+
+const calculateMinY = (components: SlabComponent[], variables: Record<string, number>, currentY = 0): number => {
+  let minY = currentY;
+  for (const comp of components) {
+    const posY = evaluateExpression(comp.position[1], variables);
+    const compMinY = currentY + posY;
+    if (compMinY < minY) minY = compMinY;
+
+    if (comp.children && comp.children.length > 0) {
+      const childrenMinY = calculateMinY(comp.children, variables, currentY + posY);
+      if (childrenMinY < minY) minY = childrenMinY;
+    }
+  }
+  return minY;
+};
+
+export const StoneForgeViewer = ({ components, variables }: StoneForgeViewerProps) => {
+  const minY = useMemo(() => {
+    return calculateMinY(components, variables);
+  }, [components, variables]);
+
+  if (!components || components.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full w-full bg-gray-50 text-gray-400 text-sm">
+        No components to display.
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full relative bg-gray-50">
+      <Canvas camera={{ position: [150, 150, 200], fov: 45 }} gl={{ preserveDrawingBuffer: true }}>
+        <color attach="background" args={['#f9fafb']} />
+        <ambientLight intensity={0.5} />
+        <directionalLight position={[100, 200, 100]} intensity={1} castShadow />
+
+        <React.Suspense fallback={null}>
+          <Environment preset="city" />
+          <group position={[-100, 0, 50]}>
+            {components.map(comp => (
+              <Slab3D
+                key={comp.id}
+                slab={comp}
+                isSelected={false}
+                onSelect={() => {}}
+                selectedComponentId={null}
+                onEdgeSelect={() => {}}
+                selectedEdge={null}
+                selectedDimensionLabelId={null}
+                variables={variables}
+              />
+            ))}
+            <Grid
+              position={[100, minY - 0.1, -50]}
+              args={[500, 500]}
+              cellSize={10}
+              cellThickness={1}
+              cellColor="#e5e7eb"
+              sectionSize={50}
+              sectionThickness={1.5}
+              sectionColor="#d1d5db"
+              fadeDistance={400}
+              fadeStrength={1}
+            />
+          </group>
+        </React.Suspense>
+
+        <OrbitControls makeDefault minDistance={10} maxDistance={1000} />
+      </Canvas>
+    </div>
+  );
+};


### PR DESCRIPTION
This pull request integrates the 3D Template Gallery directly into the Estimate workflow. It introduces a Snapshot Pattern to ensure that templates attached to estimates remain completely immutable, securing historical estimates against future template alterations.

### Changes Included:
- **Backend Schema:** Added `attachedTemplateSchema` containing `sourceTemplateId`, `snapshot`, and `variableOverrides`.
- **UI Integrations:** `NewItemForm` now features an "Add from Gallery" option, popping open `TemplateGalleryModal`.
- **3D Visualization:** When a template is attached, the form dynamically shifts into a split-pane layout showing a `StoneForgeViewer` and allowing configuration strictly via `StoneForgeVariableEditor`.
- **Data Protection:** Implements deep-copy logic to effectively seal the snapshot and variable overrides directly into the line item's payload.

---
*PR created automatically by Jules for task [14171508634804363052](https://jules.google.com/task/14171508634804363052) started by @jhoncr*