### PR TITLE
feat: Add visual indicator for attached templates in ItemsList

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -198,7 +198,9 @@
       "viewExpanded": "Expanded",
       "viewAggregated": "Aggregated",
       "headerItemTotal": "Subtotal",
-      "headerService": "Service"
+      "headerService": "Service",
+      "editItemAnd3DModel": "Edit Item & 3D Model",
+      "contains3DTemplate": "Contains 3D Template Configuration"
     }
   },
   "contactInfo": {

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -198,7 +198,9 @@
       "viewExpanded": "Expandido",
       "viewAggregated": "Agregado",
       "headerItemTotal": "Subtotal",
-      "headerService": "Serviço"
+      "headerService": "Serviço",
+      "editItemAnd3DModel": "Editar Item e Modelo 3D",
+      "contains3DTemplate": "Contém Configuração de Modelo 3D"
     }
   },
   "contactInfo": {

--- a/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/ItemsList.tsx
+++ b/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/ItemsList.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { EllipsisVertical, ListTree, List } from "lucide-react";
+import { EllipsisVertical, ListTree, List, Box } from "lucide-react";
 import { LineItem } from "@/../../backend/functions/src/common/schemas/estimate_schema";
 import { useTranslations } from "next-intl";
 import {
@@ -8,6 +8,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { useState } from "react";
 
@@ -149,6 +155,25 @@ export const ItemsList = ({
                     <span>+ {t("headerService")}</span>
                   )}
                 </div>
+                {item.attachedTemplate && (
+                  <div className="mt-1">
+                    <TooltipProvider>
+                      <Tooltip delayDuration={300}>
+                        <TooltipTrigger asChild>
+                          <div className="inline-flex items-center gap-1 text-2xs text-muted-foreground bg-secondary/30 px-1.5 py-0.5 rounded-sm w-fit border border-secondary/50">
+                            <Box className="h-3 w-3" />
+                            <span className="truncate max-w-[150px] sm:max-w-[200px]">
+                              {item.attachedTemplate.snapshot?.name}
+                            </span>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent side="right">
+                          <p>{t("contains3DTemplate")}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                )}
               </td>
               <td className="py-1 px-1 text-right align-top font-semibold">
                 {currencyFormat(item.total)}
@@ -178,6 +203,8 @@ export const ItemsList = ({
                     >
                       {editingItem?.id === item.id
                         ? "Editing..."
+                        : item.attachedTemplate
+                        ? t("editItemAnd3DModel")
                         : t("editItem")}
                     </DropdownMenuItem>
                     <DropdownMenuItem
@@ -277,6 +304,25 @@ export const ItemsList = ({
                     ) : null}
                   </span>
                 </div>
+                {item.attachedTemplate && (
+                  <div className="mt-1">
+                    <TooltipProvider>
+                      <Tooltip delayDuration={300}>
+                        <TooltipTrigger asChild>
+                          <div className="inline-flex items-center gap-1 text-2xs text-muted-foreground bg-secondary/30 px-1.5 py-0.5 rounded-sm w-fit border border-secondary/50">
+                            <Box className="h-3 w-3" />
+                            <span className="truncate max-w-[150px] sm:max-w-[200px]">
+                              {item.attachedTemplate.snapshot?.name}
+                            </span>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent side="right">
+                          <p>{t("contains3DTemplate")}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                )}
               </td>
               <td className="py-1 px-1 text-left align-top">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:gap-1 items-start w-min">
@@ -330,6 +376,8 @@ export const ItemsList = ({
                     >
                       {editingItem?.id === item.id
                         ? "Editing..."
+                        : item.attachedTemplate
+                        ? t("editItemAnd3DModel")
                         : t("editItem")}
                     </DropdownMenuItem>
                     <DropdownMenuItem

--- a/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/ItemsList.tsx
+++ b/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/ItemsList.tsx
@@ -34,6 +34,32 @@ interface AggregatedItem extends LineItem {
   total: number;
 }
 
+const AttachedTemplateIndicator = ({ name }: { name?: string }) => {
+  const t = useTranslations("estimate.itemsList");
+
+  if (!name) return null;
+
+  return (
+    <div className="mt-1">
+      <TooltipProvider>
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <div className="inline-flex items-center gap-1 text-2xs text-muted-foreground bg-secondary/30 px-1.5 py-0.5 rounded-sm w-fit border border-secondary/50">
+              <Box className="h-3 w-3" />
+              <span className="truncate max-w-[150px] sm:max-w-[200px]">
+                {name}
+              </span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p>{t("contains3DTemplate")}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+};
+
 export const ItemsList = ({
   confirmedItems,
   removeConfirmedItem,
@@ -155,25 +181,9 @@ export const ItemsList = ({
                     <span>+ {t("headerService")}</span>
                   )}
                 </div>
-                {item.attachedTemplate && (
-                  <div className="mt-1">
-                    <TooltipProvider>
-                      <Tooltip delayDuration={300}>
-                        <TooltipTrigger asChild>
-                          <div className="inline-flex items-center gap-1 text-2xs text-muted-foreground bg-secondary/30 px-1.5 py-0.5 rounded-sm w-fit border border-secondary/50">
-                            <Box className="h-3 w-3" />
-                            <span className="truncate max-w-[150px] sm:max-w-[200px]">
-                              {item.attachedTemplate.snapshot?.name}
-                            </span>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent side="right">
-                          <p>{t("contains3DTemplate")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
-                )}
+                <AttachedTemplateIndicator
+                  name={item.attachedTemplate?.snapshot?.name}
+                />
               </td>
               <td className="py-1 px-1 text-right align-top font-semibold">
                 {currencyFormat(item.total)}
@@ -304,25 +314,9 @@ export const ItemsList = ({
                     ) : null}
                   </span>
                 </div>
-                {item.attachedTemplate && (
-                  <div className="mt-1">
-                    <TooltipProvider>
-                      <Tooltip delayDuration={300}>
-                        <TooltipTrigger asChild>
-                          <div className="inline-flex items-center gap-1 text-2xs text-muted-foreground bg-secondary/30 px-1.5 py-0.5 rounded-sm w-fit border border-secondary/50">
-                            <Box className="h-3 w-3" />
-                            <span className="truncate max-w-[150px] sm:max-w-[200px]">
-                              {item.attachedTemplate.snapshot?.name}
-                            </span>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent side="right">
-                          <p>{t("contains3DTemplate")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
-                )}
+                <AttachedTemplateIndicator
+                  name={item.attachedTemplate?.snapshot?.name}
+                />
               </td>
               <td className="py-1 px-1 text-left align-top">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:gap-1 items-start w-min">


### PR DESCRIPTION
Adds a new visual indicator for estimate line items that have an attached 3D template. Displays a `Box` icon and the template name with a tooltip, improving scannability for users. Additionally, updates the "Edit Item" dropdown menu text for these items to "Edit Item & 3D Model".

Includes updates to i18n translation files for English and Portuguese.

---
*PR created automatically by Jules for task [4166975837580585375](https://jules.google.com/task/4166975837580585375) started by @jhoncr*