### PR TITLE
Feature: Clean Technical Drawing Export & Estimate Print Layout

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -198,7 +198,9 @@
       "viewExpanded": "Expanded",
       "viewAggregated": "Aggregated",
       "headerItemTotal": "Subtotal",
-      "headerService": "Service"
+      "headerService": "Service",
+      "editItemAnd3DModel": "Edit Item & 3D Model",
+      "contains3DTemplate": "Contains 3D Template Configuration"
     }
   },
   "contactInfo": {

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -198,7 +198,9 @@
       "viewExpanded": "Expandido",
       "viewAggregated": "Agregado",
       "headerItemTotal": "Subtotal",
-      "headerService": "Serviço"
+      "headerService": "Serviço",
+      "editItemAnd3DModel": "Editar Item e Modelo 3D",
+      "contains3DTemplate": "Contém Configuração de Modelo 3D"
     }
   },
   "contactInfo": {

--- a/frontend/src/app/(auth)/journal/entry/technical-drawings/page.tsx
+++ b/frontend/src/app/(auth)/journal/entry/technical-drawings/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React, { useEffect, useState, useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+import { fetchEntry, fetchJournal } from "@/lib/db_handler";
+import { EstimateHeader } from "../../journal-types/estimate/subcomponents/header";
+import { StoneForgeViewer } from "@/components/studio/StoneForgeViewer";
+import { estimateDetailsStateSchema } from "@backend/common/schemas/estimate_schema";
+import { format } from "date-fns";
+
+export default function TechnicalDrawingsPrintLayout() {
+  const searchParams = useSearchParams();
+  const journalId = searchParams.get("jid");
+  const entryId = searchParams.get("eid");
+
+  const [loading, setLoading] = useState(true);
+  const [estimateData, setEstimateData] = useState<any>(null);
+  const [journalData, setJournalData] = useState<any>(null);
+
+  useEffect(() => {
+    async function loadData() {
+      if (!journalId || !entryId) return;
+
+      try {
+        const [entryRes, journalRes] = await Promise.all([
+          fetchEntry(journalId, "estimate", entryId),
+          fetchJournal(journalId),
+        ]);
+
+        if (entryRes) {
+          // Parse the entry details against the schema to ensure we have valid estimate details
+          // DBentry implements EntryItf which has a `details` property where the specific state is stored
+          const parsed = estimateDetailsStateSchema.safeParse(entryRes.details);
+          if (parsed.success) {
+            // Note: entryRes.createdAt is a Firestore Timestamp
+            setEstimateData({ ...parsed.data, createdAt: entryRes.createdAt?.toDate ? entryRes.createdAt.toDate().toISOString() : new Date().toISOString() });
+          } else {
+            console.error("Failed to parse estimate data", parsed.error);
+          }
+        }
+
+        if (journalRes) {
+          setJournalData(journalRes);
+        }
+      } catch (err) {
+        console.error("Failed to fetch data for technical drawings", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadData();
+  }, [journalId, entryId]);
+
+  useEffect(() => {
+    // Wait for data to load and a short delay for 3D canvases to render before printing
+    if (!loading && estimateData) {
+      const timer = setTimeout(() => {
+        window.print();
+      }, 1500); // Give Three.js some time to render
+      return () => clearTimeout(timer);
+    }
+  }, [loading, estimateData]);
+
+  if (loading) {
+    return <div className="p-10 text-center">Loading technical drawings...</div>;
+  }
+
+  if (!estimateData || !journalData) {
+    return <div className="p-10 text-center text-red-600">Failed to load data.</div>;
+  }
+
+  // Filter items that have an attached template
+  const printableItems = estimateData.confirmedItems.filter(
+    (item: any) => item.attachedTemplate != null
+  );
+
+  if (printableItems.length === 0) {
+    return (
+      <div className="p-10 text-center">
+        No items with technical drawings found in this estimate.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-white text-black p-8 font-sans max-w-4xl mx-auto">
+      {/* Hide standard app UI using print media query or just rely on the clean route */}
+      <style dangerouslySetInnerHTML={{ __html: `
+        @media print {
+          body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+          @page { margin: 0.5in; size: portrait; }
+        }
+      `}} />
+
+      <EstimateHeader
+        logo={journalData.image}
+        contactInfo={journalData.contactInfo}
+      />
+
+      <div className="mt-8 mb-6 border-b pb-4 flex justify-between items-end">
+        <div>
+          <h2 className="text-2xl font-bold">Technical Drawings</h2>
+          <p className="text-gray-600 mt-1">
+            Estimate #{entryId?.slice(-6).toUpperCase()}
+          </p>
+        </div>
+        <div className="text-right text-sm">
+          <p><strong>Date:</strong> {estimateData.createdAt ? format(new Date(estimateData.createdAt), "MMMM d, yyyy") : 'N/A'}</p>
+          {estimateData.customer && (
+            <div className="mt-2">
+              <p><strong>Customer:</strong> {estimateData.customer.name}</p>
+              {estimateData.customer.phone && <p>{estimateData.customer.phone}</p>}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-12">
+        {printableItems.map((item: any, index: number) => {
+          const template = item.attachedTemplate;
+          if (!template) return null;
+
+          // Merge default variables with overrides
+          const mergedVariables: Record<string, number> = {};
+          template.snapshot.variables.forEach((v: any) => {
+            if (v.label) {
+              mergedVariables[v.label] = v.default;
+            }
+          });
+
+          if (template.variableOverrides) {
+            Object.entries(template.variableOverrides).forEach(([id, value]) => {
+              const variable = template.snapshot.variables.find((v: any) => v.id === id);
+              if (variable && variable.label) {
+                mergedVariables[variable.label] = value as number;
+              }
+            });
+          }
+
+          return (
+            <div key={item.id} className="break-inside-avoid border rounded-lg overflow-hidden border-gray-200">
+              <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex justify-between items-center">
+                <h3 className="text-lg font-semibold">
+                  {index + 1}. {item.description || template.snapshot.name}
+                </h3>
+              </div>
+
+              <div className="w-full h-[400px] bg-white relative print:h-[500px]">
+                <StoneForgeViewer
+                  components={template.snapshot.components}
+                  variables={mergedVariables}
+                  printMode={true}
+                />
+              </div>
+
+              <div className="bg-white px-4 py-4 border-t border-gray-200">
+                <h4 className="text-sm font-semibold mb-2 text-gray-700">Dimensions & Variables</h4>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                  {template.snapshot.variables.map((v: any) => {
+                    const value = template.variableOverrides?.[v.id] ?? v.default;
+                    return (
+                      <div key={v.id} className="text-sm">
+                        <span className="text-gray-500 block text-xs uppercase tracking-wide">{v.label}</span>
+                        <span className="font-medium">{value}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(auth)/journal/entry/technical-drawings/page.tsx
+++ b/frontend/src/app/(auth)/journal/entry/technical-drawings/page.tsx
@@ -4,9 +4,12 @@ import React, { useEffect, useState, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { fetchEntry, fetchJournal } from "@/lib/db_handler";
 import { EstimateHeader } from "../../journal-types/estimate/subcomponents/header";
+import { InvoiceDetails } from "../../journal-types/estimate/subcomponents/InvoiceDetails";
+import { ContactInfo } from "../../journal-types/estimate/subcomponents/ContactInfo";
 import { StoneForgeViewer } from "@/components/studio/StoneForgeViewer";
 import { estimateDetailsStateSchema } from "@backend/common/schemas/estimate_schema";
 import { format } from "date-fns";
+import { AlertCircle } from "lucide-react";
 
 export default function TechnicalDrawingsPrintLayout() {
   const searchParams = useSearchParams();
@@ -89,7 +92,7 @@ export default function TechnicalDrawingsPrintLayout() {
       <style dangerouslySetInnerHTML={{ __html: `
         @media print {
           body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-          @page { margin: 0.5in; size: portrait; }
+          @page { margin: 1cm; size: portrait; }
         }
       `}} />
 
@@ -98,21 +101,37 @@ export default function TechnicalDrawingsPrintLayout() {
         contactInfo={journalData.contactInfo}
       />
 
-      <div className="mt-8 mb-6 border-b pb-4 flex justify-between items-end">
-        <div>
-          <h2 className="text-2xl font-bold">Technical Drawings</h2>
-          <p className="text-gray-600 mt-1">
-            Estimate #{entryId?.slice(-6).toUpperCase()}
-          </p>
+      <div className="print:hidden bg-blue-50 border-l-4 border-blue-400 p-4 mb-6 rounded-md shadow-sm">
+        <div className="flex">
+          <div className="flex-shrink-0">
+            <AlertCircle className="h-5 w-5 text-blue-400" />
+          </div>
+          <div className="ml-3">
+            <p className="text-sm text-blue-700">
+              <strong>Printing Tip:</strong> For best results, enable &quot;Headers and footers&quot; and &quot;Background graphics&quot; in your browser&apos;s print settings to ensure page numbers and styling appear correctly.
+            </p>
+          </div>
         </div>
-        <div className="text-right text-sm">
-          <p><strong>Date:</strong> {estimateData.createdAt ? format(new Date(estimateData.createdAt), "MMMM d, yyyy") : 'N/A'}</p>
-          {estimateData.customer && (
-            <div className="mt-2">
-              <p><strong>Customer:</strong> {estimateData.customer.name}</p>
-              {estimateData.customer.phone && <p>{estimateData.customer.phone}</p>}
-            </div>
-          )}
+      </div>
+
+      <div className="mt-4 mb-6 pb-2">
+        <h2 className="text-2xl font-bold uppercase tracking-wider text-gray-800 border-b-2 border-gray-200 pb-2 mb-4">
+          Technical Drawings
+        </h2>
+
+        <InvoiceDetails
+          entryId={entryId}
+          createdDate={estimateData.createdAt ? new Date(estimateData.createdAt) : null}
+          status={estimateData.status}
+          handleStatusChange={() => {}} // Read-only
+        />
+
+        <div className="mt-4">
+          <h3 className="font-semibold text-gray-700 text-sm mb-2">CLIENT</h3>
+          <ContactInfo
+            info={estimateData.customer}
+            setInfo={() => {}} // Read-only
+          />
         </div>
       </div>
 
@@ -141,12 +160,12 @@ export default function TechnicalDrawingsPrintLayout() {
           return (
             <div key={item.id} className="break-inside-avoid border rounded-lg overflow-hidden border-gray-200">
               <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex justify-between items-center">
-                <h3 className="text-lg font-semibold">
+                <h3 className="text-lg font-semibold text-gray-800">
                   {index + 1}. {item.description || template.snapshot.name}
                 </h3>
               </div>
 
-              <div className="w-full h-[400px] bg-white relative print:h-[500px]">
+              <div className="w-full aspect-[4/3] relative overflow-hidden bg-white">
                 <StoneForgeViewer
                   components={template.snapshot.components}
                   variables={mergedVariables}

--- a/frontend/src/app/(auth)/journal/journal-types/estimate/addEstimate.tsx
+++ b/frontend/src/app/(auth)/journal/journal-types/estimate/addEstimate.tsx
@@ -196,6 +196,17 @@ export const EstimateDetails = React.memo(function EstimateDetails(
           </Link>
         </Button>
         <div className="flex items-center space-x-2">
+          {confirmedItems.some(item => !!item.attachedTemplate) && (
+            <Button variant="outline" asChild size="sm" disabled={isSaving}>
+              <Link
+                href={`/journal/entry/technical-drawings?jid=${props.journalId}&eid=${entryId}`}
+                target="_blank"
+              >
+                <Printer className="h-4 w-4 mr-2" />
+                Print Technical Drawings
+              </Link>
+            </Button>
+          )}
           <Button
             variant="brutalist"
             size="sm"

--- a/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/ItemsList.tsx
+++ b/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/ItemsList.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { EllipsisVertical, ListTree, List } from "lucide-react";
+import { EllipsisVertical, ListTree, List, Box } from "lucide-react";
 import { LineItem } from "@/../../backend/functions/src/common/schemas/estimate_schema";
 import { useTranslations } from "next-intl";
 import {
@@ -8,6 +8,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { useState } from "react";
 
@@ -27,6 +33,32 @@ interface AggregatedItem extends LineItem {
   itemTotal: number;
   total: number;
 }
+
+const AttachedTemplateIndicator = ({ name }: { name?: string }) => {
+  const t = useTranslations("estimate.itemsList");
+
+  if (!name) return null;
+
+  return (
+    <div className="mt-1">
+      <TooltipProvider>
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <div className="inline-flex items-center gap-1 text-2xs text-muted-foreground bg-secondary/30 px-1.5 py-0.5 rounded-sm w-fit border border-secondary/50">
+              <Box className="h-3 w-3" />
+              <span className="truncate max-w-[150px] sm:max-w-[200px]">
+                {name}
+              </span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p>{t("contains3DTemplate")}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+};
 
 export const ItemsList = ({
   confirmedItems,
@@ -149,6 +181,9 @@ export const ItemsList = ({
                     <span>+ {t("headerService")}</span>
                   )}
                 </div>
+                <AttachedTemplateIndicator
+                  name={item.attachedTemplate?.snapshot?.name}
+                />
               </td>
               <td className="py-1 px-1 text-right align-top font-semibold">
                 {currencyFormat(item.total)}
@@ -178,6 +213,8 @@ export const ItemsList = ({
                     >
                       {editingItem?.id === item.id
                         ? "Editing..."
+                        : item.attachedTemplate
+                        ? t("editItemAnd3DModel")
                         : t("editItem")}
                     </DropdownMenuItem>
                     <DropdownMenuItem
@@ -277,6 +314,9 @@ export const ItemsList = ({
                     ) : null}
                   </span>
                 </div>
+                <AttachedTemplateIndicator
+                  name={item.attachedTemplate?.snapshot?.name}
+                />
               </td>
               <td className="py-1 px-1 text-left align-top">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:gap-1 items-start w-min">
@@ -330,6 +370,8 @@ export const ItemsList = ({
                     >
                       {editingItem?.id === item.id
                         ? "Editing..."
+                        : item.attachedTemplate
+                        ? t("editItemAnd3DModel")
                         : t("editItem")}
                     </DropdownMenuItem>
                     <DropdownMenuItem

--- a/frontend/src/components/studio/StoneForgeViewer.tsx
+++ b/frontend/src/components/studio/StoneForgeViewer.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useMemo } from 'react';
-import { Canvas } from '@react-three/fiber';
+import React, { useMemo, useEffect } from 'react';
+import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls, Environment, Grid } from '@react-three/drei';
+import * as THREE from 'three';
 import { SlabComponent } from "@backend/common/schemas/studio";
 import { evaluateExpression } from '../../lib/evaluator';
 import { Slab3D } from './Slab3D';
@@ -10,7 +11,38 @@ import { Slab3D } from './Slab3D';
 interface StoneForgeViewerProps {
   components: SlabComponent[];
   variables: Record<string, number>;
+  printMode?: boolean;
 }
+
+const CameraFramer = () => {
+  const { camera, scene } = useThree();
+
+  useEffect(() => {
+    // Wait a brief moment to ensure all meshes are created
+    const timeout = setTimeout(() => {
+      const boundingBox = new THREE.Box3().setFromObject(scene);
+      if (boundingBox.isEmpty()) return;
+
+      const center = boundingBox.getCenter(new THREE.Vector3());
+      const size = boundingBox.getSize(new THREE.Vector3());
+
+      const maxDim = Math.max(size.x, size.y, size.z);
+      const fov = (camera as THREE.PerspectiveCamera).fov * (Math.PI / 180);
+
+      let cameraZ = Math.abs(maxDim / 2 / Math.tan(fov / 2));
+      cameraZ *= 1.5; // Add a little padding so it's not right on the edge
+
+      // Position the camera slightly elevated and angled
+      camera.position.set(center.x, center.y + (maxDim * 0.5), center.z + cameraZ);
+      camera.lookAt(center);
+      camera.updateProjectionMatrix();
+    }, 100);
+
+    return () => clearTimeout(timeout);
+  }, [camera, scene]);
+
+  return null;
+};
 
 const calculateMinY = (components: SlabComponent[], variables: Record<string, number>, currentY = 0): number => {
   let minY = currentY;
@@ -27,7 +59,7 @@ const calculateMinY = (components: SlabComponent[], variables: Record<string, nu
   return minY;
 };
 
-export const StoneForgeViewer = ({ components, variables }: StoneForgeViewerProps) => {
+export const StoneForgeViewer = ({ components, variables, printMode = false }: StoneForgeViewerProps) => {
   const minY = useMemo(() => {
     return calculateMinY(components, variables);
   }, [components, variables]);
@@ -41,9 +73,10 @@ export const StoneForgeViewer = ({ components, variables }: StoneForgeViewerProp
   }
 
   return (
-    <div className="w-full h-full relative bg-gray-50">
+    <div className={`w-full h-full relative ${printMode ? 'bg-white' : 'bg-gray-50'}`}>
       <Canvas camera={{ position: [150, 150, 200], fov: 45 }} gl={{ preserveDrawingBuffer: true }}>
-        <color attach="background" args={['#f9fafb']} />
+        <color attach="background" args={[printMode ? '#ffffff' : '#f9fafb']} />
+        {printMode && <CameraFramer />}
         <ambientLight intensity={0.5} />
         <directionalLight position={[100, 200, 100]} intensity={1} castShadow />
 
@@ -63,22 +96,24 @@ export const StoneForgeViewer = ({ components, variables }: StoneForgeViewerProp
                 variables={variables}
               />
             ))}
-            <Grid
-              position={[100, minY - 0.1, -50]}
-              args={[500, 500]}
-              cellSize={10}
-              cellThickness={1}
-              cellColor="#e5e7eb"
-              sectionSize={50}
-              sectionThickness={1.5}
-              sectionColor="#d1d5db"
-              fadeDistance={400}
-              fadeStrength={1}
-            />
+            {!printMode && (
+              <Grid
+                position={[100, minY - 0.1, -50]}
+                args={[500, 500]}
+                cellSize={10}
+                cellThickness={1}
+                cellColor="#e5e7eb"
+                sectionSize={50}
+                sectionThickness={1.5}
+                sectionColor="#d1d5db"
+                fadeDistance={400}
+                fadeStrength={1}
+              />
+            )}
           </group>
         </React.Suspense>
 
-        <OrbitControls makeDefault minDistance={10} maxDistance={1000} />
+        <OrbitControls makeDefault minDistance={10} maxDistance={1000} enabled={!printMode} />
       </Canvas>
     </div>
   );


### PR DESCRIPTION
This submission implements the "Clean Technical Drawing Export & Estimate Print Layout" feature.

Key updates:
1. **Three.js Enhancements**: Modified `StoneForgeViewer` to accept a `printMode` prop. When active, it sets the background to solid white, hides the grid, and disables orbit controls. It also includes a `CameraFramer` component that calculates the bounding box (`THREE.Box3`) of the scene and adjusts the camera Z-position and lookAt to perfectly frame the model for the snapshot.
2. **Estimate Details Action**: Added a "Print Technical Drawings" button next to the standard print button in the estimate view (`addEstimate.tsx`). It conditionally renders based on the presence of an `attachedTemplate` and links to the new print layout in a new tab to preserve the user's editing session.
3. **Dedicated Print Route**: Created a clean, minimal route at `/journal/entry/technical-drawings/page.tsx`. It bypasses the app shell and fetches immutable entry and journal data directly. It displays the header with business and customer details, iterates through the confirmed items, and renders the `StoneForgeViewer` in `printMode` alongside a formatted table of configured variable overrides.
4. **Auto-Print Mechanism**: Included a `setTimeout` to automatically trigger `window.print()` once the models have loaded into the scene.

---
*PR created automatically by Jules for task [8415763938993613707](https://jules.google.com/task/8415763938993613707) started by @jhoncr*