### PR TITLE
Fix Header Data Propagation and Design Truncation on Technical Drawings Print Page

### DIFF
--- a/frontend/src/app/(auth)/journal/entry/technical-drawings/page.tsx
+++ b/frontend/src/app/(auth)/journal/entry/technical-drawings/page.tsx
@@ -97,8 +97,8 @@ export default function TechnicalDrawingsPrintLayout() {
       `}} />
 
       <EstimateHeader
-        logo={journalData.image}
-        contactInfo={journalData.contactInfo}
+        logo={journalData.details?.logo}
+        contactInfo={journalData.details?.contactInfo}
       />
 
       <div className="print:hidden bg-blue-50 border-l-4 border-blue-400 p-4 mb-6 rounded-md shadow-sm">
@@ -165,7 +165,7 @@ export default function TechnicalDrawingsPrintLayout() {
                 </h3>
               </div>
 
-              <div className="w-full aspect-[4/3] relative overflow-hidden bg-white">
+              <div className="w-full min-h-[400px] relative overflow-hidden bg-white">
                 <StoneForgeViewer
                   components={template.snapshot.components}
                   variables={mergedVariables}

--- a/frontend/src/components/studio/StoneForgeViewer.tsx
+++ b/frontend/src/components/studio/StoneForgeViewer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useEffect } from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
-import { OrbitControls, Environment, Grid } from '@react-three/drei';
+import { OrbitControls, Environment, Grid, Bounds } from '@react-three/drei';
 import * as THREE from 'three';
 import { SlabComponent } from "@backend/common/schemas/studio";
 import { evaluateExpression } from '../../lib/evaluator';
@@ -14,35 +14,6 @@ interface StoneForgeViewerProps {
   printMode?: boolean;
 }
 
-const CameraFramer = () => {
-  const { camera, scene } = useThree();
-
-  useEffect(() => {
-    // Wait a brief moment to ensure all meshes are created
-    const timeout = setTimeout(() => {
-      const boundingBox = new THREE.Box3().setFromObject(scene);
-      if (boundingBox.isEmpty()) return;
-
-      const center = boundingBox.getCenter(new THREE.Vector3());
-      const size = boundingBox.getSize(new THREE.Vector3());
-
-      const maxDim = Math.max(size.x, size.y, size.z);
-      const fov = (camera as THREE.PerspectiveCamera).fov * (Math.PI / 180);
-
-      let cameraZ = Math.abs(maxDim / 2 / Math.tan(fov / 2));
-      cameraZ *= 1.5; // Add a little padding so it's not right on the edge
-
-      // Position the camera slightly elevated and angled
-      camera.position.set(center.x, center.y + (maxDim * 0.5), center.z + cameraZ);
-      camera.lookAt(center);
-      camera.updateProjectionMatrix();
-    }, 100);
-
-    return () => clearTimeout(timeout);
-  }, [camera, scene]);
-
-  return null;
-};
 
 const calculateMinY = (components: SlabComponent[], variables: Record<string, number>, currentY = 0): number => {
   let minY = currentY;
@@ -76,15 +47,15 @@ export const StoneForgeViewer = ({ components, variables, printMode = false }: S
     <div className={`w-full h-full relative ${printMode ? 'bg-white' : 'bg-gray-50'}`}>
       <Canvas camera={{ position: [150, 150, 200], fov: 45 }} gl={{ preserveDrawingBuffer: true }}>
         <color attach="background" args={[printMode ? '#ffffff' : '#f9fafb']} />
-        {printMode && <CameraFramer />}
         <ambientLight intensity={0.5} />
         <directionalLight position={[100, 200, 100]} intensity={1} castShadow />
 
         <React.Suspense fallback={null}>
           <Environment preset="city" />
-          <group position={[-100, 0, 50]}>
-            {components.map(comp => (
-              <Slab3D
+          <Bounds fit clip observe margin={1.2}>
+            <group position={[-100, 0, 50]}>
+              {components.map(comp => (
+                <Slab3D
                 key={comp.id}
                 slab={comp}
                 isSelected={false}
@@ -96,21 +67,22 @@ export const StoneForgeViewer = ({ components, variables, printMode = false }: S
                 variables={variables}
               />
             ))}
-            {!printMode && (
-              <Grid
-                position={[100, minY - 0.1, -50]}
-                args={[500, 500]}
-                cellSize={10}
-                cellThickness={1}
-                cellColor="#e5e7eb"
-                sectionSize={50}
-                sectionThickness={1.5}
-                sectionColor="#d1d5db"
-                fadeDistance={400}
-                fadeStrength={1}
-              />
-            )}
-          </group>
+              {!printMode && (
+                <Grid
+                  position={[100, minY - 0.1, -50]}
+                  args={[500, 500]}
+                  cellSize={10}
+                  cellThickness={1}
+                  cellColor="#e5e7eb"
+                  sectionSize={50}
+                  sectionThickness={1.5}
+                  sectionColor="#d1d5db"
+                  fadeDistance={400}
+                  fadeStrength={1}
+                />
+              )}
+            </group>
+          </Bounds>
         </React.Suspense>
 
         <OrbitControls makeDefault minDistance={10} maxDistance={1000} enabled={!printMode} />


### PR DESCRIPTION
This updates the technical drawings printing layout to correctly propagate the journal header details by accessing the proper `details` nested fields instead of legacy schemas. It also updates the `StoneForgeViewer` to use `@react-three/drei`'s `Bounds` component instead of manual camera calculations, providing robust framing and eliminating truncation during print views.

---
*PR created automatically by Jules for task [18271160223718306246](https://jules.google.com/task/18271160223718306246) started by @jhoncr*