### PR TITLE
Feature: Fast Template Search & Cache

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -19,7 +19,7 @@ service cloud.firestore {
 
       match /{subcol}/{entryID} {
         // Check if the user has access to the parent log, the parent log is active, AND entry is active.
-        allow read: if hasAccessAndIsActive(journalId) && (resource.data.isActive == true || resource.data.isActive == null);
+        allow read: if hasAccessAndIsActive(journalId) && (!('isActive' in resource.data) || resource.data.isActive == true || resource.data.isActive == null);
       }
     }
   }

--- a/backend/functions/src/bg-template-cache.ts
+++ b/backend/functions/src/bg-template-cache.ts
@@ -1,0 +1,63 @@
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { initializeApp, getApps } from 'firebase-admin/app';
+import * as logger from 'firebase-functions/logger';
+
+if (getApps().length === 0) {
+  initializeApp();
+}
+
+const db = getFirestore();
+
+export const onTemplateWritten = onDocumentWritten(
+  'journals/{journalId}/templates/{templateId}',
+  async (event) => {
+    const { journalId, templateId } = event.params;
+    const cacheDocRef = db.doc(`journals/${journalId}/fast-cache/templates`);
+
+    // If the document was deleted
+    if (!event.data?.after.exists) {
+      logger.info(`Template ${templateId} deleted. Removing from cache...`);
+      await cacheDocRef.set(
+        { [templateId]: FieldValue.delete() },
+        { merge: true }
+      );
+      return;
+    }
+
+    // If it was created or updated
+    const data = event.data.after.data();
+    if (!data) return;
+
+    // A "soft delete" could be indicated by isActive === false
+    if (data.isActive === false) {
+      logger.info(`Template ${templateId} is inactive. Removing from cache...`);
+      await cacheDocRef.set(
+        { [templateId]: FieldValue.delete() },
+        { merge: true }
+      );
+      return;
+    }
+
+    // Extract relevant fields
+    const name = data.name || "Untitled Template";
+    const details = data.details || {};
+    let description = details.description || "";
+    if (description.length > 200) {
+      description = description.substring(0, 200);
+    }
+    const thumbnailUrl = details.thumbnailUrl || "";
+
+    const cacheEntry: Record<string, string> = { n: name };
+    if (description) cacheEntry.d = description;
+    if (thumbnailUrl) cacheEntry.t = thumbnailUrl;
+
+    logger.info(`Updating cache for template ${templateId}`);
+
+    // Ensure the fast-cache document and templates map exists
+    await cacheDocRef.set(
+      { [templateId]: cacheEntry },
+      { merge: true }
+    );
+  }
+);

--- a/backend/functions/src/common/schemas/studio.ts
+++ b/backend/functions/src/common/schemas/studio.ts
@@ -76,6 +76,7 @@ export type CameraView = z.infer<typeof CameraViewSchema>;
 export const AssemblyTemplateSchema = z.object({
   id: z.string(),
   name: z.string(),
+  description: z.string().max(200).optional(),
   variables: z.array(AssemblyVariableSchema),
   components: z.array(SlabComponentSchema),
   cameraViews: z.array(CameraViewSchema).optional(),

--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -21,3 +21,4 @@ exports.deleteEntry = deleteEntry; // Export new function
 exports.duplicateEntry = duplicateEntry; // Export generic duplicate function
 // exports.saveTemplate = saveTemplate; // Replaced by addLogFn
 // exports.saveDesign = saveDesign; // Deleted legacy design tool
+export * from './bg-template-cache';

--- a/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/TemplateGalleryModal.tsx
+++ b/frontend/src/app/(auth)/journal/journal-types/estimate/subcomponents/TemplateGalleryModal.tsx
@@ -1,13 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogClose, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Box, Loader2 } from "lucide-react";
-import { useFetchEntries } from "../../../comp/useFetch";
+import { Box, Loader2, Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
 import Image from "next/image";
 import { AssemblyTemplate } from "@backend/common/schemas/studio";
 import { DBentry } from "@/lib/custom_types";
 import { getStorage, ref, getDownloadURL } from "firebase/storage";
 import { app } from "@/lib/auth_handler";
+import { getFirestore, doc, getDoc } from "firebase/firestore";
 
 interface TemplateGalleryModalProps {
   journalId: string;
@@ -15,27 +16,60 @@ interface TemplateGalleryModalProps {
   disabled?: boolean;
 }
 
+interface CacheEntry {
+  n: string; // name
+  d?: string; // description
+  t?: string; // thumbnailUrl
+}
+
 export function TemplateGalleryModal({ journalId, onSelectTemplate, disabled }: TemplateGalleryModalProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const { list: templates, loading, error } = useFetchEntries(journalId, "template");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cacheMap, setCacheMap] = useState<Record<string, CacheEntry>>({});
+  const [searchTerm, setSearchTerm] = useState("");
   const [imageUrls, setImageUrls] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const fetchCache = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const db = getFirestore(app);
+        const cacheDocRef = doc(db, `journals/${journalId}/fast-cache/templates`);
+        const snapshot = await getDoc(cacheDocRef);
+        if (snapshot.exists()) {
+          setCacheMap(snapshot.data() as Record<string, CacheEntry>);
+        } else {
+          setCacheMap({});
+        }
+      } catch (err: any) {
+        console.error("Failed to fetch templates cache:", err);
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCache();
+  }, [isOpen, journalId]);
 
   useEffect(() => {
     let isMounted = true;
     const fetchUrls = async () => {
       const storage = getStorage(app);
       const newUrls: Record<string, string> = {};
-      for (const entry of templates) {
-        const template = entry.details as AssemblyTemplate;
-        if (template.thumbnailUrl) {
-          if (template.thumbnailUrl.startsWith("http")) {
-            newUrls[entry.id] = template.thumbnailUrl;
+      for (const [id, entry] of Object.entries(cacheMap)) {
+        if (entry.t) {
+          if (entry.t.startsWith("http") || entry.t.startsWith("data:")) {
+            newUrls[id] = entry.t;
           } else {
             try {
-              const url = await getDownloadURL(ref(storage, template.thumbnailUrl));
-              newUrls[entry.id] = url;
+              const url = await getDownloadURL(ref(storage, entry.t));
+              newUrls[id] = url;
             } catch (e) {
-              console.error("Failed to fetch image url for", entry.id, e);
+              console.error("Failed to fetch image url for", id, e);
             }
           }
         }
@@ -44,16 +78,48 @@ export function TemplateGalleryModal({ journalId, onSelectTemplate, disabled }: 
         setImageUrls(newUrls);
       }
     };
-    if (templates.length > 0) {
+    if (Object.keys(cacheMap).length > 0) {
       fetchUrls();
     }
     return () => { isMounted = false; };
-  }, [templates]);
+  }, [cacheMap]);
 
-  const handleSelect = (templateEntry: DBentry) => {
-    onSelectTemplate(templateEntry);
-    setIsOpen(false);
+  const handleSelect = async (templateId: string) => {
+    setLoading(true);
+    try {
+      const db = getFirestore(app);
+      const templateDocRef = doc(db, `journals/${journalId}/templates`, templateId);
+      const snapshot = await getDoc(templateDocRef);
+      if (snapshot.exists()) {
+        const data = snapshot.data();
+        const templateEntry: DBentry = {
+          id: snapshot.id,
+          name: data.name,
+          details: data.details,
+          createdAt: data.createdAt,
+          updatedAt: data.updatedAt,
+          createdBy: data.createdBy,
+          isActive: data.isActive,
+        };
+        onSelectTemplate(templateEntry);
+        setIsOpen(false);
+      } else {
+        setError("Template no longer exists.");
+      }
+    } catch (err: any) {
+      console.error("Failed to fetch full template:", err);
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
   };
+
+  const filteredTemplates = Object.entries(cacheMap).filter(([_, entry]) => {
+    const term = searchTerm.toLowerCase();
+    const matchesName = entry.n?.toLowerCase().includes(term);
+    const matchesDesc = entry.d?.toLowerCase().includes(term);
+    return matchesName || matchesDesc;
+  });
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -68,10 +134,23 @@ export function TemplateGalleryModal({ journalId, onSelectTemplate, disabled }: 
           <Box size={16} /> Add from Gallery
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
+      <DialogContent aria-describedby={undefined} className="max-w-4xl max-h-[80vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>Template Gallery</DialogTitle>
         </DialogHeader>
+
+        <div className="px-4 py-2">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search templates..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+        </div>
+
         <div className="flex-1 overflow-y-auto p-4">
           {loading ? (
             <div className="flex justify-center items-center h-40">
@@ -81,53 +160,56 @@ export function TemplateGalleryModal({ journalId, onSelectTemplate, disabled }: 
             <div className="text-center text-red-500 py-8">
               Failed to load templates: {error}
             </div>
-          ) : templates.length === 0 ? (
+          ) : Object.keys(cacheMap).length === 0 ? (
             <div className="text-center text-muted-foreground py-12">
               <Box className="h-12 w-12 mx-auto mb-4 opacity-20" />
               <p>No templates found in this journal.</p>
               <p className="text-sm mt-2">Go to the Journal to create your first template.</p>
             </div>
+          ) : filteredTemplates.length === 0 ? (
+            <div className="text-center text-muted-foreground py-12">
+              <p>No templates match your search.</p>
+            </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-              {templates.map((templateEntry) => {
-                const template = templateEntry.details as AssemblyTemplate;
-                return (
-                  <div
-                    key={templateEntry.id}
-                    className="border rounded-lg p-4 cursor-pointer hover:border-primary hover:bg-accent/50 transition-colors flex flex-col group"
-                    onClick={() => handleSelect(templateEntry)}
-                  >
-                    <div className="bg-secondary/30 rounded-md h-32 w-full mb-3 flex items-center justify-center relative overflow-hidden">
-                       {template.thumbnailUrl ? (
-                         imageUrls[templateEntry.id] ? (
-                           <Image
-                             src={imageUrls[templateEntry.id]}
-                             alt={template.name || templateEntry.name || "Template thumbnail"}
-                             fill
-                             className="object-cover"
-                             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                           />
-                         ) : (
-                           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground z-10" />
-                         )
-                       ) : (
-                         <Box className="h-10 w-10 text-muted-foreground/40 group-hover:text-primary/40 transition-colors z-10" />
-                       )}
-                    </div>
-                    <h3 className="font-semibold text-sm truncate" title={template.name || templateEntry.name}>
-                      {template.name || templateEntry.name || "Untitled Template"}
-                    </h3>
-                    <div className="flex justify-between items-center mt-auto pt-2">
-                       <span className="text-xs text-muted-foreground">
-                         {template.components?.length || 0} component(s)
-                       </span>
-                       <Button size="sm" variant="secondary" className="h-7 text-xs">
-                         Select
-                       </Button>
-                    </div>
+              {filteredTemplates.map(([id, entry]) => (
+                <div
+                  key={id}
+                  className="border rounded-lg p-4 cursor-pointer hover:border-primary hover:bg-accent/50 transition-colors flex flex-col group"
+                  onClick={() => handleSelect(id)}
+                >
+                  <div className="bg-secondary/30 rounded-md h-32 w-full mb-3 flex items-center justify-center relative overflow-hidden">
+                    {entry.t ? (
+                      imageUrls[id] ? (
+                        <Image
+                          src={imageUrls[id]}
+                          alt={entry.n || "Template thumbnail"}
+                          fill
+                          className="object-cover"
+                          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                        />
+                      ) : (
+                        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground z-10" />
+                      )
+                    ) : (
+                      <Box className="h-10 w-10 text-muted-foreground/40 group-hover:text-primary/40 transition-colors z-10" />
+                    )}
                   </div>
-                );
-              })}
+                  <h3 className="font-semibold text-sm truncate" title={entry.n}>
+                    {entry.n || "Untitled Template"}
+                  </h3>
+                  {entry.d && (
+                    <p className="text-xs text-muted-foreground line-clamp-2 mt-1">
+                      {entry.d}
+                    </p>
+                  )}
+                  <div className="flex justify-end items-center mt-auto pt-2">
+                    <Button size="sm" variant="secondary" className="h-7 text-xs">
+                      Select
+                    </Button>
+                  </div>
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/frontend/src/components/studio/StoneForgeEditor.tsx
+++ b/frontend/src/components/studio/StoneForgeEditor.tsx
@@ -1982,8 +1982,51 @@ export const StoneForgeEditor = () => {
                     </div>
                   </div>
                 ) : (
-                  <div className="text-sm text-gray-500 text-center mt-10">
-                    Select a component to edit its properties.
+                  <div className="space-y-6">
+                    <div>
+                      <h4 className="text-sm font-bold text-gray-900 capitalize mb-1 flex items-center gap-1.5">
+                        <Settings className="w-4 h-4 text-indigo-600" /> Global Properties
+                      </h4>
+                      <p className="text-xs text-gray-500 mb-4">
+                        Configure the template properties.
+                      </p>
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700 mb-1">
+                        Template Name
+                      </label>
+                      <input
+                        type="text"
+                        value={template.name}
+                        onChange={(e) =>
+                          setTemplate((prev) => ({
+                            ...prev,
+                            name: e.target.value,
+                          }))
+                        }
+                        className="w-full text-sm border border-gray-300 rounded-md px-2 py-1.5 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700 mb-1">
+                        Description (Optional)
+                      </label>
+                      <textarea
+                        value={template.description || ""}
+                        maxLength={200}
+                        onChange={(e) =>
+                          setTemplate((prev) => ({
+                            ...prev,
+                            description: e.target.value,
+                          }))
+                        }
+                        className="w-full text-sm border border-gray-300 rounded-md px-2 py-1.5 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 min-h-[80px]"
+                        placeholder="Add a brief description (up to 200 characters)..."
+                      />
+                      <div className="text-[10px] text-right mt-1 text-gray-400">
+                        {(template.description || "").length}/200
+                      </div>
+                    </div>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
### Objective
1. Add a `description` field (max 200 characters) to the template schema and designer UI.
2. Implement a centralized `fast-cache` document in Firestore that aggregates lightweight metadata (id, name, description, thumbnailUrl) for all templates in a journal.
3. Update the `TemplateGalleryModal` to fetch only the cache document and perform instant client-side filtering.

### Implementation
- Added `description` to `AssemblyTemplateSchema`.
- Included Description in `StoneForgeEditor.tsx` global properties section.
- Added `bg-template-cache` Cloud Function to build `fast-cache/templates` on `journals/{journalId}/templates/{templateId}` writes. Handles both hard and soft deletes.
- Updated `TemplateGalleryModal` to replace `useFetchEntries` with a direct call to the cached document and perform direct caching queries for `.filter()` search.
- Updated security rules to allow read of subcollections without the `isActive` attribute, accommodating the `fast-cache` generic fetch pattern.

---
*PR created automatically by Jules for task [13889855591377345179](https://jules.google.com/task/13889855591377345179) started by @jhoncr*